### PR TITLE
Requirements changed for laravel 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.5",
-        "illuminate/mail": "~5.5",
-        "illuminate/filesystem": "~5.5"
+        "illuminate/support": ">=5.5",
+        "illuminate/mail": ">=5.5",
+        "illuminate/filesystem": ">=5.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.1",


### PR DESCRIPTION
Needed to install Laravel 6.

This might not perhaps be the best composer requirement method but given that this is a non-critical dev component should be ok.